### PR TITLE
Proposal for a docs working group

### DIFF
--- a/wg-update-docs/README.md
+++ b/wg-update-docs/README.md
@@ -1,0 +1,17 @@
+
+# Update Documentation Working Group
+
+The goal of this working group is to update the existing ODH documentation to reflect the current state of the project and to add data scientists users’ perspectives to the documentation. This group should also focus on creating a common thread that ties all the docs together with a single (or as few as possible) Machine Learning tasks that can be be solved with ODH.    
+
+The [charter](charter.md) defines the scope and governance of the DevSecOps Working Group.
+
+## Meetings
+* Regular WG Meeting: TBD
+
+## Organizers
+
+* Michael Clifford (**[@MichaelClifford](https://github.com/MichaelClifford)**), Red Hat
+* Landon LaSmith (**[@LaVLaS](https://github.com/LaVLaS)**), Red Hat
+
+## Contact
+- [Open Community Issues/PRs](https://github.com/opendatahub-io/opendatahub-community/issues)

--- a/wg-update-docs/charter.md
+++ b/wg-update-docs/charter.md
@@ -1,0 +1,23 @@
+# Working Group - Update Docs 
+
+## Scope
+The goal of this working group is to update the existing ODH documentation to reflect the current state of the project and to add data scientists users’ perspectives to the documentation. This group should also focus on creating a common thread that ties all the docs together with a single (or as few as possible) Machine Learning tasks that can be be solved with ODH.    
+
+### In scope
+* Update existing documentation. 
+* Write new documentation.
+* Create tutorials as part of documentation. 
+
+### Out of scope
+* Suggesting new ODH components. 
+* Creating docs for components not yet implemented in core ODH. 
+
+## Deliverables 
+Documentation and tutorials as markdown files added to the [opendatahub.io repo](https://github.com/opendatahub-io/opendatahub.io).
+
+## Stakeholders
+* [OSG SIG Data Science](https://github.com/open-services-group/community/tree/main/sig-data-science)
+* [Open Data Hub Community](https://github.com/opendatahub-io/opendatahub-community) 
+
+## Disband Criteria
+All issues with the "Documentation Update" prefix in the [opendatahub.io repo](https://github.com/opendatahub-io/opendatahub.io) are closed. 


### PR DESCRIPTION
Adding a proposal for a working group between the ODH community and members of the Open Services Group to collaborate on updating the docs in https://github.com/opendatahub-io/opendatahub.io .