### PR TITLE
Update mlops sig

### DIFF
--- a/sig-ml-ops/OWNERS
+++ b/sig-ml-ops/OWNERS
@@ -3,14 +3,14 @@
 approvers:
 
 - anishasthana
-- crobby
+- gmfrasca
 - njhill
 - panbalag
 
 reviewers:
 
 - anishasthana
-- crobby
+- gmfrasca
 - njhill
 - panbalag
 

--- a/sig-ml-ops/README.md
+++ b/sig-ml-ops/README.md
@@ -8,7 +8,7 @@ This document defines the scope and governance of the ML Ops Special Interest Gr
 
 * SIG Meeting Invite: <https://meet.google.com/xfx-takq-cyq>
 * Meeting Agenda: [Notes - ML Ops SIG](https://docs.google.com/document/d/1FRgjYrr6q-phoeopC6Nl8c4AX2uma7oOXn6vNkBZ7Qg/edit)
-* Cadence: 14:00 - 15:00 Eastern time every 2nd Wednesday, starting June 15th
+* Cadence: 12:00 - 13:00 Eastern time every 2nd Wednesday
 
 ## Chairs
 

--- a/sig-ml-ops/README.md
+++ b/sig-ml-ops/README.md
@@ -17,7 +17,7 @@ The Chairs of the SIG run operations and processes governing the SIG
 * Prasanth Anbalagan: panbalag
 * Anish Asthana: anishasthana
 * Nick Hill: njhill
-* Chad Roberts: crobby
+* Giulio Frasca: gmfrasca
 
 **Members**:
 

--- a/sig-ml-ops/README.md
+++ b/sig-ml-ops/README.md
@@ -21,11 +21,13 @@ The Chairs of the SIG run operations and processes governing the SIG
 
 **Members**:
 
-The members of the SIG establish new subprojects, decommission existing subprojects, and resolve cross-subproject technical issues and decisions
+The members of these teams within the SIG establish new subprojects, decommission existing subprojects, and resolve cross-subproject technical issues and decisions
 
-* Dharmit Dalvi
-* Giulio Frasca
-* Ricardo Martinelli de Oliveira
+* Data Science Pipelines
+* Model Serving
+* AI Explainability
+
+_#TODO: Link to GitHub Teams once created_
 
 **Contact:**
 


### PR DESCRIPTION
Update ML Ops SIG chairs and members, and correct some additional metadata

## Description
- Replace `crobby` with `gmfrasca` as SIG chair
- Update SIG members to reference teams rather than individuals
- Correct the meeting time listed in the SIG README

## How Has This Been Tested?
N/A

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
