### PR TITLE
Create templates for using the ODH Community Rep

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["kind/bug", "untriaged"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please, fill this form to help us improve the project.
+  - type: dropdown
+    attributes:
+      label: ODH Component
+      description: Which ODH Component is affected by this issue?
+      multiple: false
+      options:
+        - ODH Operator
+        - ODH Dashboard
+        - ODH Notebook Controller
+        - ODH Workbench Images
+        - Data Science Pipelines
+        - Model Serving
+        - AI Explainability
+        - Distributed Workloads
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround (if any)
+      description: Any manual steps that allow you to resolve the issue
+      placeholder: Tell us the steps you followed to resolve the issue!
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on? (If applicable)
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+    validations:
+      required: false
+  - type: textarea
+    id: opendatahub-version
+    attributes:
+      label: Open Data Hub Version
+      description: Please attach relevant kfdef manifest if applicable
+      render: yml
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else
+      description: Any additional information you'd like to share
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here is an excerpt from the code of conduct:
 - **Website** - Documentation is published at [opendatahub.io](https://opendatahub.io)
 - **YouTube** - Videos of Open Data Hub and other related content can be seen on the [AI/ML OpenShift YouTube channel](https://www.youtube.com/playlist?list=PLaR6Rq6Z4Iqcg2znnClv-xbj93Q_wcY8L).
 - **Open Data Hub Blog** - Read various blogs about Open Data Hub and its releases on the [Open Data Hub news page](https://opendatahub.io/news.html).
+- **Bug Reports** - Any bugs with Open Data Hub can be reported to the [issues](https://github.com/opendatahub-io/opendatahub-community/issues) page where it will be reviewed and triaged by the relevant component owners
 
 ## Meeting Agenda and Notes
 Meeting agenda can be found in the document ["Open Data Hub Community Meeting Agenda"](https://docs.google.com/document/d/1u6Kwn_uBwrlYnEE1wBkK-7USXCFuD_0IU8gKhGdfuuw/edit?usp=sharing).

--- a/contributing.md
+++ b/contributing.md
@@ -78,4 +78,4 @@ Consider contributing to documentation to improve install instructions, tutorial
 
 Helping to manage or triage open issues in repositories can be a great contribution and a great opportunity to learn about the various areas of the project.
 
-Triaging is the word we use to describe the process of adding multiple types of descriptive labels to GitHub issues, in order to speed up routing issues to the right folks.
+Triaging is the word we use to describe the process of adding multiple types of descriptive labels to GitHub issues, in order to speed up routing issues to the right folks.  If you experience any issues affecting the Open Data Hub community or the components, please file an issue under the [opendatahub-community](https://github.com/opendatahub-io/odh-dashboard/issues).  The issue will be reviewed and triaged by the relevant component owners and transfered to the affected code repositories under the [opendatahub-io organization](https://github.com/opendatahub-io).


### PR DESCRIPTION
This implements the ODH community issue template for bugs & feature requests with the labels outlined in https://github.com/opendatahub-io/architecture-decision-records/pull/9.  

Once merged this repository will be the ODH user entrypoint for creating any issues for any untriaged ODH component before being transferred to the respective component repository where the work is performed